### PR TITLE
fix: remove specific vscode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,9 +2,6 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "bradlc.vscode-tailwindcss",
     "neotan.vscode-auto-restart-typescript-eslint-servers",
-    "prisma.prisma",
-    "qwtel.sqlite-viewer"
   ]
 }


### PR DESCRIPTION
The workshop template contains VS Code extensions recommendations that aren't applicable to all workshops. This PR cleans up those extensions, leaving only those applicable to all workshops by default. 