### PR TITLE
Update Node.js and npm versions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ speed on some of the tools and concepts we'll be covering:
 ## System Requirements
 
 - [git][git] v2.18 or greater
-- [NodeJS][node] v18 or greater
-- [npm][npm] v8 or greater
+- [NodeJS][node] v24 or greater
+- [npm][npm] v9 or greater
 
 All of these must be available in your `PATH`. To verify things are set up
 properly, you can run this:


### PR DESCRIPTION
We list Node.js engine as `>=24` in `package.json` but the README still says "v18 or greater". v18 has long been EOL, so I'm updating the README to prevent confusion. 